### PR TITLE
add aerial spawn item pull configs

### DIFF
--- a/manip.cfg
+++ b/manip.cfg
@@ -119,3 +119,19 @@ TT3 Fox Kirby Pichu Roy
 
 NAME Seed Test 9b380178
 SEED 9b380178
+
+NAME Peach Airborne Spawn Bomb Pull
+# 43 = 12 (from stage load) + 31 (from landing dust)
+DELAY 43
+INT 128 0 0
+INT 6 0 1
+ 
+NAME Peach Airborne Spawn Saturn Pull
+DELAY 43
+INT 128 0 0
+INT 6 2 4
+ 
+NAME Peach Airborne Spawn Beamsword Pull
+DELAY 43
+INT 128 0 0
+INT 6 5 5


### PR DESCRIPTION
Inserts additional config entries for peach item pulls accounting for landing dust when spawning in the air.